### PR TITLE
Replace cl with cl-lib

### DIFF
--- a/ace-jump-mode.el
+++ b/ace-jump-mode.el
@@ -30,7 +30,7 @@
 ;; What's this?
 ;;
 ;; It is a minor mode for Emacs. It can help you to move your cursor
-;; to ANY position in emacs by using only 3 times key press. 
+;; to ANY position in emacs by using only 3 times key press.
 
 ;; Where does ace jump mode come from ?
 ;;
@@ -58,7 +58,7 @@
 ;; ----------------------------------------------------------
 ;; ;;
 ;; ;; ace jump mode major function
-;; ;; 
+;; ;;
 ;; (add-to-list 'load-path "/full/path/where/ace-jump-mode.el/in/")
 ;; (autoload
 ;;   'ace-jump-mode
@@ -68,7 +68,7 @@
 ;; ;; you can select the key you prefer to
 ;; (define-key global-map (kbd "C-c SPC") 'ace-jump-mode)
 ;;
-;; ;; 
+;; ;;
 ;; ;; enable a more powerful jump back function from ace jump mode
 ;; ;;
 ;; (autoload
@@ -79,7 +79,7 @@
 ;; (eval-after-load "ace-jump-mode"
 ;;   '(ace-jump-mode-enable-mark-sync))
 ;; (define-key global-map (kbd "C-x SPC") 'ace-jump-mode-pop-mark)
-;; 
+;;
 ;; ;;If you use viper mode :
 ;; (define-key viper-vi-global-user-map (kbd "SPC") 'ace-jump-mode)
 ;; ;;If you use evil
@@ -447,10 +447,10 @@ node and call LEAF-FUNC on each leaf node"
 
 (defun ace-jump-populate-overlay-to-search-tree (tree candidate-list)
   "Populate the overlay to search tree, every leaf will give one overlay"
-  
+
   (lexical-let* (;; create the locally dynamic variable for the following function
                  (position-list candidate-list)
-                 
+
                  ;; make the function to create overlay for each leaf node,
                  ;; here we only create each overlay for each candidate
                  ;; position, , but leave the 'display property to be empty,
@@ -466,7 +466,7 @@ node and call LEAF-FUNC on each leaf node"
                                           (setf (cdr node) ol)
                                           (overlay-put ol 'face 'ace-jump-face-foreground)
                                           ;; this is important, because sometimes the different
-                                          ;; window may dispaly the same buffer, in that case, 
+                                          ;; window may dispaly the same buffer, in that case,
                                           ;; overlay for different window (but the same buffer)
                                           ;; will show at the same time on both window
                                           ;; So we make it only on the specific window
@@ -558,7 +558,7 @@ node and call LEAF-FUNC on each leaf node"
                                        :window w
                                        :frame (selected-frame))))
    ((eq ace-jump-mode-scope 'window)
-    (list 
+    (list
      (make-aj-visual-area :buffer (current-buffer)
                           :window (selected-window)
                           :frame  (selected-frame))))
@@ -659,7 +659,7 @@ You can constrol whether use the case sensitive via `ace-jump-mode-case-fold'.
     (if (and (frame-live-p frame)
              (not (eq frame (selected-frame))))
         (select-frame-set-input-focus (window-frame window)))
-    
+
     ;; select the correct window
     (if (and (window-live-p window)
              (not (eq window (selected-window))))
@@ -705,7 +705,7 @@ You can constrol whether use the case sensitive via `ace-jump-mode-case-fold'.
               (not (buffer-live-p (aj-position-buffer
                                    (car ace-jump-mode-mark-ring)))))
     (setq ace-jump-mode-mark-ring (cdr ace-jump-mode-mark-ring)))
-    
+
   (if (null ace-jump-mode-mark-ring)
       ;; no valid history exist
       (error "[AceJump] No more history"))
@@ -726,9 +726,9 @@ You can constrol whether use the case sensitive via `ace-jump-mode-case-fold'.
                   (move-marker (car mark-ring) nil)
                   (setq mark-ring (cdr mark-ring))
                   (deactivate-mark))
-              
+
               ;;  But if there is other marker put before the wanted destination, the following scenario
-              ;;                                                           
+              ;;
               ;;             +---+---+---+---+                                   +---+---+---+---+
               ;;   Mark Ring | 2 | 3 | 4 | 5 |                                   | 2 | 4 | 5 | 3 |
               ;;             +---+---+---+---+                                   +---+---+---+---+
@@ -738,17 +738,17 @@ You can constrol whether use the case sensitive via `ace-jump-mode-case-fold'.
               ;;             +---+                                               +---+
               ;;   Cursor    | X |                     Pop up AJ mark 3          | 3 | <-- Cursor position
               ;;             +---+                                               +---+
-              ;;             +---+---+---+                                       +---+---+---+ 
+              ;;             +---+---+---+                                       +---+---+---+
               ;;   AJ Ring   | 3 | 4 | 5 |                                       | 4 | 5 | 3 |
               ;;             +---+---+---+                                       +---+---+---+
-              ;;   
+              ;;
               ;; So what we need to do, is put the found mark in mark-ring to the end
               (lexical-let ((po (aj-position-offset p)))
                 (setq mark-ring
                       (ace-jump-move-first-to-end-if mark-ring
                                                      (lambda (x)
                                                        (equal (marker-position x) po))))))
-              
+
 
           ;; when we jump back to another buffer, do as the
           ;; pop-global-mark does. But we move the marker with the
@@ -758,8 +758,8 @@ You can constrol whether use the case sensitive via `ace-jump-mode-case-fold'.
                   (ace-jump-move-first-to-end-if global-mark-ring
                                                  (lambda (x)
                                                    (eq (marker-buffer x) pb))))))))
-          
-  
+
+
   ;; move the first element to the end of the ring
   (ace-jump-jump-to (car ace-jump-mode-mark-ring))
   (setq ace-jump-mode-mark-ring (nconc (cdr ace-jump-mode-mark-ring)
@@ -800,7 +800,7 @@ word-mode and char-mode"
   ;; when you trigger the key for ace jump again when already in ace
   ;; jump mode.  So we stop the previous one first.
   (if ace-jump-current-mode (ace-jump-done))
-  
+
   (if (eq (ace-jump-char-category query-char) 'other)
     (error "[AceJump] Non-printable character"))
 
@@ -858,7 +858,7 @@ Marked each no empty line and move there"
   ;; when you trigger the key for ace jump again when already in ace
   ;; jump mode.  So we stop the previous one first.
   (if ace-jump-current-mode (ace-jump-done))
-  
+
   (setq ace-jump-current-mode 'ace-jump-line-mode)
   (ace-jump-do "^"))
 
@@ -998,7 +998,7 @@ Such as : (lambda (x) (equal x 1)) "
                                    nil
                                  (setq found (funcall pred x)))))))
 
-  
+
 
 (defadvice pop-mark (before ace-jump-pop-mark-advice)
   "When `pop-mark' is called to jump back, this advice will sync the mark ring.
@@ -1011,7 +1011,7 @@ Move the same position to the end of `ace-jump-mode-mark-ring'."
                                              (lambda (x)
                                                (and (equal (aj-position-offset x) mp)
                                                     (eq (aj-position-buffer x) cb))))))))
-            
+
 
 (defadvice pop-global-mark (before ace-jump-pop-global-mark-advice)
   "When `pop-global-mark' is called to jump back, this advice will sync the mark ring.
@@ -1029,7 +1029,7 @@ Move the aj-position with the same buffer to the end of `ace-jump-mode-mark-ring
                 (ace-jump-move-to-end-if ace-jump-mode-mark-ring
                                          (lambda (x)
                                            (eq (aj-position-buffer x) mb))))))))
-                                              
+
 
 (defun ace-jump-mode-enable-mark-sync ()
   "Enable the sync funciton between ace jump mode mark ring and emacs mark ring.
@@ -1037,7 +1037,7 @@ Move the aj-position with the same buffer to the end of `ace-jump-mode-mark-ring
 1. This function will enable the advice which activate on
 `pop-mark' and `pop-global-mark'. These advice will remove the
 same marker from `ace-jump-mode-mark-ring' when user use
-`pop-mark' or `global-pop-mark' to jump back. 
+`pop-mark' or `global-pop-mark' to jump back.
 
 2. Set variable `ace-jump-sync-emacs-mark-ring' to t, which will
 sync mark information with emacs mark ring. "
@@ -1053,7 +1053,7 @@ sync mark information with emacs mark ring. "
 1. This function will diable the advice which activate on
 `pop-mark' and `pop-global-mark'. These advice will remove the
 same marker from `ace-jump-mode-mark-ring' when user use
-`pop-mark' or `global-pop-mark' to jump back. 
+`pop-mark' or `global-pop-mark' to jump back.
 
 2. Set variable `ace-jump-sync-emacs-mark-ring' to nil, which
 will stop synchronizing mark information with emacs mark ring. "
@@ -1068,6 +1068,6 @@ will stop synchronizing mark information with emacs mark ring. "
 
 ;;; ace-jump-mode.el ends here
 
-;; Local Variables: 
-;; byte-compile-warnings: (not cl-functions) 
-;; End: 
+;; Local Variables:
+;; byte-compile-warnings: (not cl-functions)
+;; End:


### PR DESCRIPTION
The `cl` package is deprecated; we replace it with `cl-lib`.